### PR TITLE
Feature/v0.1.1-add-github-workflow-file: Change `requirements-dev.txt` to `requirements.txt` in `publish-to-pypi.yml`

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # Install development dependencies and then the package itself
-        pip install -r requirements-dev.txt
+        pip install -r requirements.txt
         pip install .
 
     - name: Run tests with pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biochemical-data-connectors"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python package to extract chemical, biochemical, and bioactivity data from public databases like ORD, ChEMBL and PubChem."
 readme = "README.md"
 license = { text = "MIT License" }


### PR DESCRIPTION
# Description

Having the requirements file as `requirements-dev.txt` in the `publish-to-pypi.yml` file was causing the GIthub actions to error.