### PR TITLE
Feature/refactor-public-api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biochemical-data-connectors"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Python package to extract chemical, biochemical, and bioactivity data from public databases like ORD, ChEMBL and PubChem."
 readme = "README.md"
 license = { text = "MIT License" }

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,11 +1,1 @@
-"""
-BiochemicalDataConnectors: A Python package to extract chemical
-and biochemical from public databases.
-"""
 
-__version__ = "0.1.0"
-
-from src.connectors.bioactive_compounds_connectors import (BaseBioactivesConnector, ChEMBLBioactivesConnector,
-                                                        PubChemBioactivesConnector)
-
-from src.utils.api.mappings import uniprot_to_gene_id_mapping, pdb_to_uniprot_id_mapping

--- a/src/biochemical-data-connectors/__init__.py
+++ b/src/biochemical-data-connectors/__init__.py
@@ -1,0 +1,27 @@
+"""
+BiochemicalDataConnectors: A Python package to extract chemical
+and biochemical from public databases.
+"""
+from .connectors.bioactive_compounds_connectors import (
+    BaseBioactivesConnector,
+    ChEMBLBioactivesConnector,
+    PubChemBioactivesConnector
+)
+
+from .connectors.ord_connectors import OpenReactionDatabaseConnector
+
+from .utils.api.mappings import uniprot_to_gene_id_mapping, pdb_to_uniprot_id_mapping
+
+__all__ = [
+    # --- Base Classes ---
+    "BaseBioactivesConnector",
+
+    # --- Concrete Connectors / Extractors ---
+    "ChEMBLBioactivesConnector",
+    "PubChemBioactivesConnector",
+    "OpenReactionDatabaseConnector",
+
+    # --- Public Utility Functions ---
+    "uniprot_to_gene_id_mapping",
+    "pdb_to_uniprot_id_mapping",
+]


### PR DESCRIPTION
# Description
The `__init__.py` file defining the public API was in the incorrect directory, and was not defined using `__all__`. This PR resolves these issues to simplify importing this package by 3rd parties.