### PR TITLE
Feature/compound-standardization-utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biochemical-data-connectors"
-version = "0.1.6"
+version = "0.1.7"
 description = "A Python package to extract chemical, biochemical, and bioactivity data from public databases like ORD, ChEMBL and PubChem."
 readme = "README.md"
 license = { text = "MIT License" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biochemical-data-connectors"
-version = "0.1.7"
+version = "1.0.0"
 description = "A Python package to extract chemical, biochemical, and bioactivity data from public databases like ORD, ChEMBL and PubChem."
 readme = "README.md"
 license = { text = "MIT License" }

--- a/src/biochemical_data_connectors/models.py
+++ b/src/biochemical_data_connectors/models.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass, field
+from typing import Optional, Any
+
+
+@dataclass
+class BioactiveCompound:
+    """
+    A dataclass to hold standardized information about a bioactive compound.
+
+    Attributes
+    ----------
+    inchikey : str
+        The standard 27-character InChIKey for the compound's structure.
+    smiles : str
+        The canonical SMILES string representing the molecule.
+    activity_type : str
+        The type of bioactivity measurement, e.g., 'Kd', 'IC50'.
+    activity_value : float
+        The numeric value of the bioactivity, typically in nM.
+    source_db : str
+        The name of the database where the data was sourced, e.g., 'ChEMBL'.
+    source_id : str
+        The compound's primary identifier from the source database, e.g.,
+        a ChEMBL ID or a PubChem CID.
+    iupac_name : Optional[str]
+        The IUPAC name of the compound.
+    molecular_formula : Optional[str]
+        The molecular formula of the compound, e.g., 'C9H8O4'.
+    molecular_weight : Optional[float]
+        The molecular weight of the compound's free base.
+    raw_data : Optional[Any]
+        The original, unprocessed data object from the source library
+        (e.g., a `pubchempy.Compound` object) for advanced use cases.
+        The string representation of this field is hidden for clarity.
+    """
+    inchikey: str
+    smiles: str
+    activity_type: str
+    activity_value: float
+    source_db: str
+    source_id: str
+    iupac_name: Optional[str] = None
+    molecular_formula: Optional[str] = None
+    molecular_weight: Optional[float] = None
+    raw_data: Optional[Any] = field(default=None, repr=False)

--- a/src/biochemical_data_connectors/models.py
+++ b/src/biochemical_data_connectors/models.py
@@ -9,19 +9,19 @@ class BioactiveCompound:
 
     Attributes
     ----------
-    inchikey : str
-        The standard 27-character InChIKey for the compound's structure.
+    source_db : str
+        The name of the database where the data was sourced, e.g., 'ChEMBL'.
+    source_id : str
+        The compound's primary identifier from the source database, e.g.,
+        a ChEMBL ID or a PubChem CID.
+    source_inchikey : str
+        The standard 27-character InChIKey for the compound's structure from the source database.
     smiles : str
         The canonical SMILES string representing the molecule.
     activity_type : str
         The type of bioactivity measurement, e.g., 'Kd', 'IC50'.
     activity_value : float
         The numeric value of the bioactivity, typically in nM.
-    source_db : str
-        The name of the database where the data was sourced, e.g., 'ChEMBL'.
-    source_id : str
-        The compound's primary identifier from the source database, e.g.,
-        a ChEMBL ID or a PubChem CID.
     iupac_name : Optional[str]
         The IUPAC name of the compound.
     molecular_formula : Optional[str]
@@ -33,12 +33,12 @@ class BioactiveCompound:
         (e.g., a `pubchempy.Compound` object) for advanced use cases.
         The string representation of this field is hidden for clarity.
     """
-    inchikey: str
+    source_db: str
+    source_id: str
     smiles: str
     activity_type: str
     activity_value: float
-    source_db: str
-    source_id: str
+    source_inchikey: Optional[str] = None
     iupac_name: Optional[str] = None
     molecular_formula: Optional[str] = None
     molecular_weight: Optional[float] = None

--- a/src/biochemical_data_connectors/utils/standardization_utils.py
+++ b/src/biochemical_data_connectors/utils/standardization_utils.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Optional
+
+from rdkit import Chem
+from rdkit.Chem.SaltRemover import SaltRemover
+from dimorphite_dl import protonate_smiles
+
+salt_remover = SaltRemover()
+
+
+class MoleculeStandardizer:
+    def __init__(self, logger: Optional[logging.Logger]):
+        self._logger = logger if logger else logging.getLogger(__name__)
+        self._salt_remover = SaltRemover
+
+    def standardize_smiles(
+        self,
+        smiles: str,
+        ph: float = 7.4,
+        inchi_key: Optional[str] = None,
+        logger: Optional[logging.Logger] = None
+    ) -> Optional[dict]:
+        """
+        Performs a full standardization workflow on a single SMILES string.
+
+        The workflow includes:
+        1. Desalting the molecule to keep the parent structure.
+        2. Standardizing the protonation state to a specific pH using `dimorphite-dl`.
+        3. Generating a canonical SMILES string and a standard InChIKey if one is not provided.
+
+        Parameters
+        ----------
+        smiles : str
+            The input SMILES string to be standardized.
+        ph : float, optional
+            The pH at which to standardize the protonation state. Default is 7.4.
+        inchi_key : str, optional
+            A condensed, 27-character representation of a full InChi identifier.
+        logger : logging.Logger, optional
+            A logger for logging potential errors.
+
+        Returns
+        -------
+        Optional[dict]
+            A dictionary containing the 'mol', 'smiles', and 'inchi_key' of the
+            standardized molecule, or None if the input SMILES is invalid.
+        """
+        try:
+            # 1. Create initial RDKit molecule object
+            mol = Chem.MolFromSmiles(smiles)
+            if mol is None:
+                raise ValueError("Invalid input SMILES string")
+
+            # 2. Remove salts to get the parent molecule
+            parent_mol = self._salt_remover.StripMol(mol)
+            parent_smiles = Chem.MolToSmiles(parent_mol, canonical=True)
+
+            # 3. Standardize protonation state using the imported function
+            #    Ask for only one variant at the specified pH
+            protonated_smiles_list: list[str] = protonate_smiles(
+                parent_smiles, ph_min=ph, ph_max=ph, max_variants=1
+            )
+
+            if not protonated_smiles_list:
+                # If dimorphite returns nothing, use the desalted parent
+                final_smiles = parent_smiles
+            else:
+                final_smiles = protonated_smiles_list[0]
+
+            # 4. Create the final, fully standardized RDKit Mol object
+            final_mol = Chem.MolFromSmiles(final_smiles)
+            if final_mol is None:
+                raise ValueError("Failed to create molecule after standardization")
+
+            # 5. Generate final canonical representations
+            final_canonical_smiles = Chem.MolToSmiles(final_mol, canonical=True, isomericSmiles=True)
+            if inchi_key is None:
+                final_inchi_key = Chem.MolToInchiKey(final_mol)
+            else:
+                final_inchi_key = inchi_key
+
+            return {
+                "mol": final_mol,
+                "smiles": final_canonical_smiles,
+                "inchi_key": final_inchi_key
+            }
+
+        except Exception as e:
+            if logger:
+                logger.warning(f"Failed to standardize SMILES '{smiles}': {e}")
+
+            return None


### PR DESCRIPTION
# Description
**Changes**
1. Create `MoleculeStandardizer` class to standardize SMILES strings by:
* Desalting
* Standardizing the protonation state to a specific pH using `dimorphite-dl`
* Generating a canonical SMILES string and an InChIKey of the standardized molecule.
2. Create a standardized `BioactiveCompound` object that both connectors will return, instead of simply the SMILES strings of the bioactive compounds