### PR TITLE
Feature/add-target-unitprot-id-and-standardized-inchikey-attributes-to-BioactiveCompound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "biochemical-data-connectors"
-version = "3.0.2"
+version = "3.0.3"
 description = "A Python package to extract chemical, biochemical, and bioactivity data from public databases like ORD, ChEMBL and PubChem."
 readme = "README.md"
 license = { text = "MIT License" }

--- a/src/biochemical_data_connectors/connectors/bioactive_compounds/chembl_bioactives_connector.py
+++ b/src/biochemical_data_connectors/connectors/bioactive_compounds/chembl_bioactives_connector.py
@@ -106,7 +106,8 @@ class ChEMBLBioactivesConnector(BaseBioactivesConnector):
                 target_chembl_id, self._bioactivity_measures
             ),
             data_type='ChEMBL activity records',
-            force_refresh=force_refresh
+            force_refresh=force_refresh,
+            logger=self._logger
         )
         self._logger.info(f"Found {len(all_activity_records)} total activity records.")
 
@@ -198,6 +199,7 @@ class ChEMBLBioactivesConnector(BaseBioactivesConnector):
                 source_db="ChEMBL",
                 source_id=chembl_id,
                 smiles=canonical_smiles,
+                target_uniprot=target_uniprot_id,
                 source_inchikey=inchikey,
                 iupac_name=records[0].get('iupac_name', None),
                 molecular_formula=mol_formula,

--- a/src/biochemical_data_connectors/connectors/bioactive_compounds/pubchem_bioactives_connector.py
+++ b/src/biochemical_data_connectors/connectors/bioactive_compounds/pubchem_bioactives_connector.py
@@ -154,6 +154,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
         all_bioactives: List[BioactiveCompound] = get_cached_or_fetch(
             cache_file_path=bioactivecompound_cache_file,
             fetch_function=lambda: self._get_all_bioactive_compounds(
+                target_uniprot_id=target_uniprot_id,
                 pubchempy_compounds=pubchempy_compounds,
                 cid_to_bioassay_map=cid_to_bioassay_map
             ),
@@ -257,7 +258,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
                 )
                 for compound, bioassay_data in zip(compound_batch, batch_bioassay_data):
                     if bioassay_data:
-                        cid_to_bioassay_map[compound.cid] = bioassay_data
+                        cid_to_bioassay_map[str(compound.cid)] = bioassay_data
 
         potencies_api_end: float = time.time()
         self._logger.info(f"PubChem bioactive compound bioassays total API query time: "
@@ -268,6 +269,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
 
     def _get_all_bioactive_compounds(
         self,
+        target_uniprot_id: str,
         pubchempy_compounds: List[pcp.Compound],
         cid_to_bioassay_map: Dict[str, Any]
     ) -> List[BioactiveCompound]:
@@ -299,6 +301,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
                 continue
 
             compound_obj = self._create_bioactive_compound(
+                target_uniprot_id=target_uniprot_id,
                 pubchempy_compound=pubchempy_compound,
                 bioassay_data=compound_bioassay_data
             )
@@ -309,6 +312,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
 
     @staticmethod
     def _create_bioactive_compound(
+        target_uniprot_id: str,
         pubchempy_compound: pcp.Compound,
         bioassay_data: Dict[str, Any]
     ) -> Optional[BioactiveCompound]:
@@ -360,6 +364,7 @@ class PubChemBioactivesConnector(BaseBioactivesConnector):
             source_db='PubChem',
             source_id=str(pubchempy_compound.cid),
             smiles=smiles,
+            target_uniprot=target_uniprot_id,
             activity_type=bioassay_data['activity_type'],
             activity_value=bioassay_data['best_value'],
             source_inchikey=final_inchikey,

--- a/src/biochemical_data_connectors/models.py
+++ b/src/biochemical_data_connectors/models.py
@@ -14,14 +14,21 @@ class BioactiveCompound:
     source_id : str
         The compound's primary identifier from the source database, e.g.,
         a ChEMBL ID or a PubChem CID.
-    source_inchikey : str
-        The standard 27-character InChIKey for the compound's structure from the source database.
     smiles : str
         The canonical SMILES string representing the molecule.
+    target_uniprot : str
+        The UniProt accession ID of the biological target.
     activity_type : str
         The type of bioactivity measurement, e.g., 'Kd', 'IC50'.
     activity_value : float
         The numeric value of the bioactivity, typically in nM.
+    n_measurements : int
+        The total number of measurements found for the primary `activity_type`.
+    source_inchikey : str
+        The standard 27-character InChIKey for the compound's structure from the source database.
+    standardized_inchikey : Optional[str]
+        The canonical InChIKey calculated from the standardized molecular
+        structure.
     iupac_name : Optional[str]
         The IUPAC name of the compound.
     molecular_formula : Optional[str]
@@ -35,11 +42,14 @@ class BioactiveCompound:
     """
     source_db: str
     source_id: str
+    target_uniprot: str
     smiles: str
+    target_uniprot: str
     activity_type: str
     activity_value: float
     n_measurements: int
     source_inchikey: Optional[str] = None
+    standardized_inchikey: Optional[str] = None
     iupac_name: Optional[str] = None
     molecular_formula: Optional[str] = None
     molecular_weight: Optional[float] = None


### PR DESCRIPTION
# Description
**Changes**
1. Fix compound CID bug by casting to string during CID-bioassay mapping.
2. Pass logger to ChEMBL connector cache method.
3. Add standardized InChIKey and target Uniprot ID attributes to BioactiveCompounds class.